### PR TITLE
Add Lithuanian QWERTY layout with Lithuanian characters

### DIFF
--- a/Lithuanian/lithuanian_qwerty.yaml
+++ b/Lithuanian/lithuanian_qwerty.yaml
@@ -1,0 +1,7 @@
+name: Lithuanian QWERTY
+languages: lt
+rows:
+  - letters: ą č ę ė į š ų ū ž
+  - letters: q w e r t y u i o p
+  - letters: a s d f g h j k l
+  - letters: z x c v b n m

--- a/mapping.yaml
+++ b/mapping.yaml
@@ -380,6 +380,7 @@ languages:
   lo_LA:
     - lao
   lt:
+    - lithuanian_qwerty
     - qwerty
     - qwertz
     - dvorak


### PR DESCRIPTION
Lithuanian layout with the letters ą č ę ė į š ų ū ž above the standard QWERTY layout, fixes #5
![image](https://github.com/user-attachments/assets/bbce720b-4eaa-43c1-bfe9-7541e6911bbf)
