### PR TITLE
Kazakh Cyrillic and Latin layouts

### DIFF
--- a/Cyrillic/kazakh_cyrillic.yaml
+++ b/Cyrillic/kazakh_cyrillic.yaml
@@ -1,5 +1,5 @@
 name: Kazakh (Cyrillic)
-languages: kk-Cyrl
+languages: kk
 minimumFunctionalKeyWidth: 0.0
 rows:
   - letters: ё ә і ң ғ ү ұ қ ө һ ъ

--- a/Cyrillic/kazakh_cyrillic.yaml
+++ b/Cyrillic/kazakh_cyrillic.yaml
@@ -1,0 +1,8 @@
+name: Kazakh (Cyrillic)
+languages: kk-Cyrl
+minimumFunctionalKeyWidth: 0.0
+rows:
+  - letters: ё ә і ң ғ ү ұ қ ө һ ъ
+  - letters: й ц у к е н г ш щ з х
+  - letters: ф ы в а п р о л д ж э
+  - letters: я ч с м и т ь б ю

--- a/LatinScript/kazakh_latin.yaml
+++ b/LatinScript/kazakh_latin.yaml
@@ -10,7 +10,6 @@ rows:
     - t
     - y
     - u
-    - i
     - {type: case, normal: ['i'], shifted: ['İ']}
     - o
     - p

--- a/LatinScript/kazakh_latin.yaml
+++ b/LatinScript/kazakh_latin.yaml
@@ -1,5 +1,5 @@
 name: Kazakh (Latin)
-languages: kk_Latn
+languages: kk-Latn
 rows:
   - letters: ä ñ ğ ç ū ü ı ö ş
   - letters:

--- a/LatinScript/kazakh_latin.yaml
+++ b/LatinScript/kazakh_latin.yaml
@@ -1,5 +1,5 @@
 name: Kazakh (Latin)
-languages: kk-Latn
+languages: kk
 rows:
   - letters: ä ñ ğ ç ū ü ı ö ş
   - letters:

--- a/LatinScript/kazakh_latin.yaml
+++ b/LatinScript/kazakh_latin.yaml
@@ -1,5 +1,5 @@
 name: Kazakh (Latin)
-languages: kk
+languages: kk_Latn
 rows:
   - letters: ä ñ ğ ç ū ü ı ö ş
   - letters:

--- a/LatinScript/kazakh_latin.yaml
+++ b/LatinScript/kazakh_latin.yaml
@@ -1,0 +1,18 @@
+name: Kazakh (Latin)
+languages: kk-Latn
+rows:
+  - letters: ä ñ ğ ç ū ü ı ö ş
+  - letters:
+    - q
+    - w
+    - e
+    - r
+    - t
+    - y
+    - u
+    - i
+    - {type: case, normal: ['i'], shifted: ['İ']}
+    - o
+    - p
+  - letters: a s d f g h j k l
+  - letters: z x c v b n m

--- a/mapping.yaml
+++ b/mapping.yaml
@@ -365,11 +365,12 @@ languages:
     - georgian
   kk:
     - kazakh_cyrillic
-    - kazakh_latin
     - east_slavic
     - russian_student
     - russian_yavert
     - russian_yazhert
+  kk_Latn:
+    - kazakh_latin
   km_KH:
     - khmer
   kn_IN:

--- a/mapping.yaml
+++ b/mapping.yaml
@@ -364,6 +364,8 @@ languages:
   ka_GE:
     - georgian
   kk:
+    - kazakh_cyrillic
+    - kazakh_latin
     - east_slavic
     - russian_student
     - russian_yavert


### PR DESCRIPTION
* The Kazakh Cyrillic layout is based on https://kbdlayout.info/kbdkaz .
* The keyboard backend needs to be updated to support different locales `kk-Cyrl` for Cyrillic and `kk-Latn` for Latin script, but for now both layouts have the locale `kk`.
Cyrillic:
![image](https://github.com/user-attachments/assets/b8967481-9e83-4d74-93d5-63f86bd5607c)
Latin:
![image](https://github.com/user-attachments/assets/503edfb7-1efb-41f4-8c40-decfc0ddc1d5)
