### PR TITLE
Slovenian layouts

### DIFF
--- a/LatinScript/slovenian_qwerty.yaml
+++ b/LatinScript/slovenian_qwerty.yaml
@@ -1,0 +1,17 @@
+name: Slovenian QWERTY
+languages: sl
+rows:
+  - letters: q w e r t y u i o p š
+  - letters:
+    - a
+    - s
+    - ['d', 'đ']
+    - f
+    - g
+    - h
+    - j
+    - k
+    - l
+    - č
+    - ž
+  - letters: z x c v b n m

--- a/LatinScript/slovenian_qwertz.yaml
+++ b/LatinScript/slovenian_qwertz.yaml
@@ -1,0 +1,17 @@
+name: Slovenian QWERTZ
+languages: sl
+rows:
+  - letters: q w e r t z u i o p š
+  - letters:
+    - a
+    - s
+    - ['d', 'đ']
+    - f
+    - g
+    - h
+    - j
+    - k
+    - l
+    - č
+    - ž
+  - letters: y x c v b n m

--- a/mapping.yaml
+++ b/mapping.yaml
@@ -539,6 +539,8 @@ languages:
     - pcqwerty
     - nordic
   sl:
+    - slovenian_qwerty
+    - slovenian_qwertz
     - qwerty
     - qwertz
     - dvorak


### PR DESCRIPTION
* Added Slovenian QWERTY and QWERTZ layouts based on the PC layout: http://kbdlayout.info/kbdcr
* The letters Ć and Đ are from Serbo-Croatian and not in Slovenian, so they are added as long press options

QWERTY
![image](https://github.com/user-attachments/assets/787d96de-6d9a-4a10-9794-de031416f0f0)

QWERTZ
![image](https://github.com/user-attachments/assets/91041e27-06da-4c23-be29-a3b70983e38f)
