### PR TITLE
Update Serbian QWERTZ layout

### DIFF
--- a/LatinScript/serbian_qwertz.yaml
+++ b/LatinScript/serbian_qwertz.yaml
@@ -1,5 +1,6 @@
 name: Serbian QWERTZ
 languages: sr-Latn hr
+minimumFunctionalKeyWidth: 0.0
 rows:
   - letters: q w e r t z u i o p š
   - letters: a s d f g h j k l č ć


### PR DESCRIPTION
The current Serbian QWERTZ layout has keys that are too narrow in the bottom row. This can cause issues with typing, for example see https://github.com/florisboard/florisboard/issues/2092.
![image](https://github.com/user-attachments/assets/d301968b-5272-4c29-80db-1c62f628ff21)

The layout has been updated to increase the key width:
![image](https://github.com/user-attachments/assets/36ac004b-0903-4352-a385-c2bae2327909)
