### PR TITLE
Adding the QWERTY layout to the Swedish language

### DIFF
--- a/mapping.yaml
+++ b/mapping.yaml
@@ -567,6 +567,7 @@ languages:
   sr_Latn:
     - serbian_qwertz
   sv:
+    - qwerty
     - nordic
   sw:
     - qwerty


### PR DESCRIPTION
Adding the QWERTY layout to the Swedish (sv) language in the file _mapping.yaml_.
