### PR TITLE
Catalan fix (Add L·L (L with middle dot) to Catalan layout)

### DIFF
--- a/Default/spanish.yaml
+++ b/Default/spanish.yaml
@@ -2,5 +2,15 @@ name: "QWERTY+1 (Spanish)"
 languages: es ca eo pt
 rows:
   - letters: "q w e r t y u i o p"
-  - letters: "a s d f g h j k l !text/keyspec_spanish_row2_10"
+  - letters:
+    - a
+    - s
+    - d
+    - f
+    - g
+    - h
+    - j
+    - k
+    - ["l", "l·l"]
+    - "!text/keyspec_spanish_row2_10"
   - letters: "z x c v b n m"


### PR DESCRIPTION
Fixes #93 