### PR TITLE
Add Dvorak layout to Bulgarian language

### DIFF
--- a/Cyrillic/Bulgarian/bulgarian_dvorak.yaml
+++ b/Cyrillic/Bulgarian/bulgarian_dvorak.yaml
@@ -1,0 +1,36 @@
+name: Bulgarian (Dvorak)
+languages: bg
+rows:
+  - letters:
+    - {type: case, normal: "'", shifted: "\""}
+    - {type: case, normal: ",", shifted: "<"}
+    - {type: case, normal: ".", shifted: ">"}
+    - ['п']
+    - ['ъ']
+    - ['ф']
+    - ['г']
+    - ['ц']
+    - ['р']
+    - ['л']
+  - letters:
+    - ['а']
+    - ['о']
+    - ['е']
+    - ['у']
+    - ['и']
+    - ['д']
+    - ['х']
+    - ['т']
+    - ['н']
+    - ['с']
+    - ['ю']
+  - letters:
+    - ['я']
+    - ['й']
+    - ['к']
+    - ['ь']
+    - ['б']
+    - ['м']
+    - ['в']
+    - ['ж']
+    - ['з']

--- a/mapping.yaml
+++ b/mapping.yaml
@@ -43,7 +43,7 @@ languages:
   bg:
     - bulgarian
     - bulgarian_bds
-    - dvorak
+    - bulgarian_dvorak
   bn_BD:
     - bengali_akkhor
     - bengali_probhat

--- a/mapping.yaml
+++ b/mapping.yaml
@@ -43,6 +43,7 @@ languages:
   bg:
     - bulgarian
     - bulgarian_bds
+    - dvorak
   bn_BD:
     - bengali_akkhor
     - bengali_probhat


### PR DESCRIPTION
Currently the keyboard layout for the Bulgarian language doesn't include the Dvorak layout.
This feature would be useful for me and others to stick to our most comfortable layout, instead of constantly switching from English Dvorak to Bulgarian QWERTY.