### PR TITLE
Add layout with Ç to Portuguese

### DIFF
--- a/mapping.yaml
+++ b/mapping.yaml
@@ -532,6 +532,7 @@ languages:
     - pcqwerty
     - nordic
   pt_BR:
+    - spanish
     - qwerty
     - qwertz
     - dvorak
@@ -543,6 +544,7 @@ languages:
     - pcqwerty
     - nordic
   pt_PT:
+    - spanish
     - qwerty
     - qwertz
     - dvorak


### PR DESCRIPTION
Fixes https://github.com/futo-org/android-keyboard/issues/10
![image](https://github.com/user-attachments/assets/0cf43f2a-6b2a-4d55-9d05-6b14b12460a2)
