### PR TITLE
Allow hangul "shift" characters to be selected via long-press in dubeolsik layouts

### DIFF
--- a/Korean/korean_dubeolsik.yaml
+++ b/Korean/korean_dubeolsik.yaml
@@ -5,15 +5,15 @@ combiners:
 attributes: {shiftable: false}
 rows:
   - letters:
-    - {type: case, normal: ["ㅂ"], shiftedManually: ["ㅃ"]}
-    - {type: case, normal: ["ㅈ"], shiftedManually: ["ㅉ"]}
-    - {type: case, normal: ["ㄷ"], shiftedManually: ["ㄸ"]}
-    - {type: case, normal: ["ㄱ"], shiftedManually: ["ㄲ"]}
-    - {type: case, normal: ["ㅅ"], shiftedManually: ["ㅆ"]}
+    - {type: case, normal: ["ㅂ", "ㅃ"], shiftedManually: ["ㅃ"]}
+    - {type: case, normal: ["ㅈ", "ㅉ"], shiftedManually: ["ㅉ"]}
+    - {type: case, normal: ["ㄷ", "ㄸ"], shiftedManually: ["ㄸ"]}
+    - {type: case, normal: ["ㄱ", "ㄲ"], shiftedManually: ["ㄲ"]}
+    - {type: case, normal: ["ㅅ", "ㅆ"], shiftedManually: ["ㅆ"]}
     - ㅛ
     - ㅕ
     - ㅑ
-    - {type: case, normal: ["ㅐ"], shiftedManually: ["ㅒ"]}
-    - {type: case, normal: ["ㅔ"], shiftedManually: ["ㅖ"]}
+    - {type: case, normal: ["ㅐ", "ㅒ"], shiftedManually: ["ㅒ"]}
+    - {type: case, normal: ["ㅔ", "ㅖ"], shiftedManually: ["ㅖ"]}
   - letters: ㅁ ㄴ ㅇ ㄹ ㅎ ㅗ ㅓ ㅏ ㅣ
   - letters: ㅋ ㅌ ㅊ ㅍ ㅠ ㅜ ㅡ

--- a/Korean/korean_dubeolsik_combineinitials.yaml
+++ b/Korean/korean_dubeolsik_combineinitials.yaml
@@ -5,15 +5,15 @@ combiners:
 attributes: {shiftable: false}
 rows:
   - letters:
-    - {type: case, normal: ["ㅂ"], shiftedManually: ["ㅃ"]}
-    - {type: case, normal: ["ㅈ"], shiftedManually: ["ㅉ"]}
-    - {type: case, normal: ["ㄷ"], shiftedManually: ["ㄸ"]}
-    - {type: case, normal: ["ㄱ"], shiftedManually: ["ㄲ"]}
-    - {type: case, normal: ["ㅅ"], shiftedManually: ["ㅆ"]}
+    - {type: case, normal: ["ㅂ", "ㅃ"], shiftedManually: ["ㅃ"]}
+    - {type: case, normal: ["ㅈ", "ㅉ"], shiftedManually: ["ㅉ"]}
+    - {type: case, normal: ["ㄷ", "ㄸ"], shiftedManually: ["ㄸ"]}
+    - {type: case, normal: ["ㄱ", "ㄲ"], shiftedManually: ["ㄲ"]}
+    - {type: case, normal: ["ㅅ", "ㅆ"], shiftedManually: ["ㅆ"]}
     - ㅛ
     - ㅕ
     - ㅑ
-    - {type: case, normal: ["ㅐ"], shiftedManually: ["ㅒ"]}
-    - {type: case, normal: ["ㅔ"], shiftedManually: ["ㅖ"]}
+    - {type: case, normal: ["ㅐ", "ㅒ"], shiftedManually: ["ㅒ"]}
+    - {type: case, normal: ["ㅔ", "ㅖ"], shiftedManually: ["ㅖ"]}
   - letters: ㅁ ㄴ ㅇ ㄹ ㅎ ㅗ ㅓ ㅏ ㅣ
   - letters: ㅋ ㅌ ㅊ ㅍ ㅠ ㅜ ㅡ


### PR DESCRIPTION
For the Korean dubeolsik layouts, this allows the "shifted" hangul letters to be selected via long-press of the same key they are associated with. Such as selecting ㅖ or ㅃ via a long-press of ㅔ or ㅂ respectively, in addition to selecting via shift key.

This isn't a necessary change, as users can use shift, but it makes for easier transition to Futo for users coming from common keyboard apps that work this way for Korean dubeolsik layouts (such as Gboard, Samsung Keyboard, Heliboard, Swiftkey, and presumably others). 