### PR TITLE
Added North Caucasian layout

### DIFF
--- a/Cyrillic/north_caucasian.yaml
+++ b/Cyrillic/north_caucasian.yaml
@@ -1,0 +1,11 @@
+name: North Caucasian
+languages: abq ady agx av ce dar inh kbd lbe lez rut tab tkr_RU
+minimumFunctionalKeyWidth: 0.0
+rows:
+  - letters:
+    - { type: base, spec: "ё", attributes: { width: Grow } }
+    - { type: base, spec: "Ӏ", attributes: { width: Grow } }
+    - { type: base, spec: "ъ", attributes: { width: Grow } }
+  - letters: й ц у к е н г ш щ з х
+  - letters: ф ы в а п р о л д ж э
+  - letters: я ч с м и т ь б ю

--- a/mapping.yaml
+++ b/mapping.yaml
@@ -1,4 +1,8 @@
 languages:
+  abq:
+    - north_caucasian
+  ady:
+    - north_caucasian
   af:
     - qwerty
     - qwertz
@@ -12,12 +16,16 @@ languages:
     - nordic
   ak:
     - akan
+  agx:
+    - north_caucasian
   alt:
     - altai
   ar:
     - arabic
     - arabic_pc
     - lulua
+  av:
+    - north_caucasian
   az_AZ:
     - azerbaijani
     - qwerty
@@ -72,6 +80,8 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+  ce:
+    - north_caucasian
   ckb:
     - kurdish
     - central_kurdish_arabic_g
@@ -99,6 +109,8 @@ languages:
     - colemak_dh_ansi
     - bepo
     - pcqwerty
+  dar:
+    - north_caucasian
   de:
     - german
     - qwertz
@@ -365,6 +377,8 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+  inh:
+    - north_caucasian
   is:
     - icelandic
     - qwerty
@@ -420,6 +434,8 @@ languages:
     - georgian
   kaa:
     - karakalpak_latin
+  kbd:
+    - north_caucasian
   kk:
     - kazakh_cyrillic
     - east_slavic
@@ -445,6 +461,10 @@ languages:
     - russian_student
     - russian_yavert
     - russian_yazhert
+  lbe:
+    - north_caucasian
+  lez:
+    - north_caucasian
   lo_LA:
     - lao
   lt:
@@ -585,6 +605,8 @@ languages:
     - russian_student
     - russian_yavert
     - russian_yazhert
+  rut:
+    - north_caucasian
   sah:
     - yakut
   si_LK:
@@ -651,6 +673,8 @@ languages:
   ta_SG:
     - tamil_inscript
     - tamil
+  tab:
+    - north_caucasian
   te_IN:
     - telugu
   tg:
@@ -663,6 +687,8 @@ languages:
     - thai
   tk:
     - turkmen
+  tkr_RU:
+    - north_caucasian
   tl:
     - spanish
     - qwerty


### PR DESCRIPTION
Layout for some languages spoken in the Caucasus which all share the same alphabet.

![image](https://github.com/user-attachments/assets/7e067f45-e4b8-488e-bf34-1be73b0bce03)

Text on the spacebar needs to be updated for the following languages:
* abq (Abaza): абаза
* ady (Adyghe): адыгабзэ
* agx (Aghul): агъул
* av (Avar): магӏарул мацӏ
* dar (Dargwa): дарган
* inh (Ingush): гӏалгӏай
* kbd: (Kabardian): адыгэбзэ
* lbe (Lak): лакку
* lez (Lezgian): Лезги
* rut (Rutul): мыхаӀбишды чӀел
* tab (Tabasaran): табасаран чIал
* tkr_RU (Tsakhur): цӀаӀхна миз