### PR TITLE
Add Ukrainian layout which is more standard

### DIFF
--- a/Cyrillic/ukrainian_standard.yaml
+++ b/Cyrillic/ukrainian_standard.yaml
@@ -1,0 +1,19 @@
+name: Ukrainian Standard
+languages: uk
+rows:
+  - letters:
+    - [й]
+    - [ц]
+    - [у]
+    - [к]
+    - [е]
+    - [н]
+    - [г, ґ]
+    - [ш]
+    - [щ]
+    - [з]
+    - [х]
+    - [ї]
+  - letters: ф і в а п р о л д ж є '
+  - letters: я ч с м и т ь б ю
+


### PR DESCRIPTION
This keyboard layout has has ї and ., at usual positions and ґ as the superscript of г which makes the row one symbol shorter.