### PR TITLE
add ,. to Ukrainian layout, add Ukrainian G layout

### DIFF
--- a/Cyrillic/ukrainian.yaml
+++ b/Cyrillic/ukrainian.yaml
@@ -10,6 +10,6 @@ rows:
     - ['ї', ',']
     - $action
     - $space
-    - {type: case, normal: ['.'], shiftedManually: [',']}
     - ["'", '.']
+    - {type: case, normal: ['.'], shiftedManually: [',']}
     - $enter

--- a/Cyrillic/ukrainian.yaml
+++ b/Cyrillic/ukrainian.yaml
@@ -10,5 +10,6 @@ rows:
     - ['ї', ',']
     - $action
     - $space
+    - {type: case, normal: ['.'], shiftedManually: [',']}
     - ["'", '.']
     - $enter

--- a/Cyrillic/ukrainian_g.yaml
+++ b/Cyrillic/ukrainian_g.yaml
@@ -1,0 +1,18 @@
+name: Ukrainian G
+languages: uk
+rows:
+  - letters:
+    - [й]
+    - [ц]
+    - [у]
+    - [к]
+    - [е]
+    - [н]
+    - [г, ґ]
+    - [ш]
+    - [щ]
+    - [з]
+    - [х]
+    - [ї]
+  - letters: ф і в а п р о л д ж є '
+  - letters: я ч с м и т ь б ю

--- a/mapping.yaml
+++ b/mapping.yaml
@@ -734,6 +734,7 @@ languages:
     - uyghur
   uk:
     - ukrainian
+    - ukrainian_g
     - east_slavic
     - russian_student
     - russian_yavert


### PR DESCRIPTION
I had somehow forgotten to add , and . to the Ukrainian layout before, which has been fixed now.
![image](https://github.com/user-attachments/assets/8a3f5bea-5a16-4841-967a-0fa653c316f4)

Also added the "Ukrainian Standard" (renamed to "Ukrainian G", as it is based on the Gboard layout) from #176
![image](https://github.com/user-attachments/assets/46442999-22ca-49db-a08d-b398b4fbd02c)
