### PR TITLE
Update arabic.yaml to allow adding diacritics

### DIFF
--- a/ArabicScript/arabic.yaml
+++ b/ArabicScript/arabic.yaml
@@ -129,3 +129,11 @@ rows:
       - "\u062F"
 
       - "$delete"
+   
+  - bottom:
+    - $symbols
+    - ","
+    - "!icon/action_switch_language|!code/action_switch_language"
+    - $space
+    - "."
+    - $enter


### PR DESCRIPTION
Hi


Many thanks for the great keyboard.

I noted that by adding an explicit "bottom" row, writing diacritics would be possible.

Uncertain if this is a bug, or an intended feature.

```yaml
   - bottom:
    - $symbols
    - ","
    - "!icon/action_switch_language|!code/action_switch_language"
    - $space
    - "."
    - $enter
```


Best wishes,

Harvey R.