### PR TITLE
Add languages that use the same character set and layouts as English and update names.yaml

### DIFF
--- a/mapping.yaml
+++ b/mapping.yaml
@@ -85,6 +85,18 @@ languages:
   bod:
     - tibetan
     - tibetan_wylie
+  brx_Latn: # Bodo/Boro (India)
+    - qwerty
+    - qwertz
+    - dvorak
+    - azerty
+    - colemak
+    - colemak_dh
+    - colemak_dh_ansi
+    - bepo
+    - pcqwerty
+    - nordic
+    - workman
   ca:
     - spanish
     - qwerty
@@ -688,6 +700,18 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+  prk: # Wa/Parauk
+    - qwerty
+    - qwertz
+    - dvorak
+    - azerty
+    - colemak
+    - colemak_dh
+    - colemak_dh_ansi
+    - bepo
+    - pcqwerty
+    - nordic
+    - workman
   pt_BR:
     - spanish
     - qwerty
@@ -917,6 +941,18 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+  trp: # Kokborok/Tripuri
+    - qwerty
+    - qwertz
+    - dvorak
+    - azerty
+    - colemak
+    - colemak_dh
+    - colemak_dh_ansi
+    - bepo
+    - pcqwerty
+    - nordic
+    - workman
   ts: # Tsonga
     - qwerty
     - qwertz
@@ -982,6 +1018,18 @@ languages:
     - tibetan_wylie
   yrk:
     - nenets
+  za: # Zhuang
+    - qwerty
+    - qwertz
+    - dvorak
+    - azerty
+    - colemak
+    - colemak_dh
+    - colemak_dh_ansi
+    - bepo
+    - pcqwerty
+    - nordic
+    - workman
   zgh:
     - amazigh_basic
     - amazigh_extended

--- a/names.yaml
+++ b/names.yaml
@@ -5,6 +5,11 @@
 aa:
   aa: Qafar
   en: Afar
+brx_Latn:
+  en: Boro (Latin)
+  as: "বড়ো (লেটিন)"
+  brx_Latn: Boro
+  hi: "बोड़ो (लैटिन)"
 ipa:
   en: International Phonetic Alphabet
 hi_Latn:
@@ -21,6 +26,9 @@ lbj:
   bod: ལ་དྭགས་སྐད་
   en: Ladakhi
   lbj: ལ་དྭགས་སྐད་
+prk:
+  en: Wa
+  prk: Vax
 sip:
   bod: འབྲས་ལྗོངས་སྐད་
   en: Sikkimese Bhutia
@@ -31,6 +39,12 @@ sm:
 tok:
   en: Toki Pona
   tok: toki pona
+trp:
+  en: Kokborok
+  as: "ককবৰক"
+  bn: "ককবরক"
+  hi: "ककबरक"
+  trp: Kokborok
 ts:
   en: Tsonga
   ts: Xitsonga
@@ -100,13 +114,13 @@ agx:
   agx: агъул
 av:
   en: Avar
-  av: магӏарул мацӏ
+  av: магӀарул мацӀ
 dar:
   en: Dargwa
   dar: дарган
 inh:
   en: Ingush
-  inh: гӏалгӏай
+  inh: гӀалгӀай
 kbd:
   en: Kabardian
   kbd: адыгэбзэ


### PR DESCRIPTION
* There are some languages that use the same 26 letters of Basic Latin as English. For example: Afar, Somali, Greenlandic, etc. These have been added to mapping.yaml with the same layouts as English
* Added Samoan and Tongan to mapping.yaml, which use the same layout as Hawaiian
* When the added languages' names did not show up correctly, added the names to names.yaml. Also corrected English and native names of Karakalpak and Tuvan.