### PR TITLE
Add ClearFlow layout

### DIFF
--- a/Default/clearflow.yaml
+++ b/Default/clearflow.yaml
@@ -6,6 +6,7 @@ bottomRowWidthMode: Identical
 layoutSetOverrides:
   symbols: "clearflow_symbols"
   symbolsShifted: "clearflow_symbols_shift"
+supportsSplit: false
 attributes:
   moreKeyMode: OnlyFromLetter
 rows:

--- a/Default/clearflow.yaml
+++ b/Default/clearflow.yaml
@@ -19,10 +19,11 @@ rows:
     - c
     - j
     - "?"
-    - $delete
-  - letters:
     - type: base
-      spec: "!icon/action_switch_language|!code/action_switch_language"
+      spec: "!icon/delete_key|!code/key_delete"
+      attributes: { width: FunctionalKey, style: Functional, anchored: true, showPopup: false, moreKeyMode: OnlyExplicit, repeatableEnabled: true, rowSpan: 2 }
+  - letters:
+    - type: action
       attributes: { width: FunctionalKey, style: Functional, showPopup: false }
     - y
     - o
@@ -30,8 +31,8 @@ rows:
     - e
     - v
     - u
-    - type: action
-      attributes: { width: FunctionalKey, style: Functional, showPopup: false }
+    - type: gap
+      attributes: { width: Grow }
   - letters:
     - type: base
       spec: "!icon/space_key_for_number_layout|!code/key_space"

--- a/Default/clearflow.yaml
+++ b/Default/clearflow.yaml
@@ -1,0 +1,80 @@
+name: ClearFlow
+description: A high-performance layout optimized for swipe-typing accuracy and speed.
+numberRowMode: AlwaysDisabled
+bottomRowHeightMode: Flexible
+bottomRowWidthMode: Identical
+layoutSetOverrides:
+  symbols: "clearflow_symbols"
+  symbolsShifted: "clearflow_symbols_shift"
+attributes:
+  moreKeyMode: OnlyFromLetter
+rows:
+  - letters:
+    - $shift
+    - "!"
+    - q
+    - w
+    - c
+    - j
+    - "?"
+    - $delete
+  - letters:
+    - type: base
+      spec: "!icon/action_switch_language|!code/action_switch_language"
+      attributes: { width: FunctionalKey, style: Functional, showPopup: false }
+    - y
+    - o
+    - h
+    - e
+    - v
+    - u
+    - type: action
+      attributes: { width: FunctionalKey, style: Functional, showPopup: false }
+  - letters:
+    - type: base
+      spec: "!icon/space_key_for_number_layout|!code/key_space"
+      attributes: { width: Grow, style: Spacebar, showPopup: false, longPressEnabled: true, moreKeyMode: OnlyExplicit, rowSpan: 2 }
+    - x
+    - r
+    - t
+    - a
+    - l
+    - b
+    - type: base
+      spec: "!icon/space_key_for_number_layout|!code/key_space"
+      attributes: { width: Grow, style: Spacebar, showPopup: false, longPressEnabled: true, moreKeyMode: OnlyExplicit, rowSpan: 2 }
+  - letters:
+    - type: gap
+      attributes: { width: Grow }
+    - f
+    - s
+    - i
+    - n
+    - d
+    - z
+    - type: gap
+      attributes: { width: Grow }
+  - bottom:
+    - $symbols
+    - type: contextual
+      fallbackKey:
+        type: base
+        spec: ","
+        attributes: { width: FunctionalKey, style: Normal, moreKeyMode: All }
+      attributes: { width: FunctionalKey, style: Normal, moreKeyMode: All }
+    - type: base
+      spec: p
+      attributes: { width: FunctionalKey, style: Normal }
+    - type: base
+      spec: m
+      attributes: { width: FunctionalKey, style: Normal }
+    - type: base
+      spec: g
+      attributes: { width: FunctionalKey, style: Normal }
+    - type: base
+      spec: k
+      attributes: { width: FunctionalKey, style: Normal }
+    - type: base
+      spec: "."
+      attributes: { width: FunctionalKey, style: Normal, moreKeyMode: All }
+    - $enter

--- a/Default/clearflow.yaml
+++ b/Default/clearflow.yaml
@@ -6,6 +6,7 @@ bottomRowWidthMode: Identical
 layoutSetOverrides:
   symbols: "clearflow_symbols"
   symbolsShifted: "clearflow_symbols_shift"
+mirrorInOneHanded: true
 supportsSplit: false
 attributes:
   moreKeyMode: OnlyFromLetter

--- a/Default/clearflow_symbols.yaml
+++ b/Default/clearflow_symbols.yaml
@@ -2,6 +2,7 @@ name: "ClearFlow Symbols"
 numberRowMode: AlwaysDisabled
 bottomRowHeightMode: Flexible
 bottomRowWidthMode: Identical
+supportsSplit: false
 attributes:
   shiftable: false
   moreKeyMode: OnlyFromLetter

--- a/Default/clearflow_symbols.yaml
+++ b/Default/clearflow_symbols.yaml
@@ -1,0 +1,86 @@
+name: "ClearFlow Symbols"
+numberRowMode: AlwaysDisabled
+bottomRowHeightMode: Flexible
+bottomRowWidthMode: Identical
+attributes:
+  shiftable: false
+  moreKeyMode: OnlyFromLetter
+rows:
+  - letters:
+    - $shift
+    - "!"
+    - "1"
+    - "2"
+    - "3"
+    - "4"
+    - "?"
+    - type: base
+      spec: "!icon/delete_key|!code/key_delete"
+      attributes: { width: FunctionalKey, style: Functional, anchored: true, showPopup: false, moreKeyMode: OnlyExplicit, repeatableEnabled: true, rowSpan: 2 }
+  - letters:
+    - type: base
+      spec: "!icon/action_switch_language|!code/action_switch_language"
+      attributes: { width: FunctionalKey, style: Functional, showPopup: false }
+    - "5"
+    - "6"
+    - "7"
+    - "8"
+    - "9"
+    - "0"
+    - type: gap
+      attributes: { width: FunctionalKey }
+  - letters:
+    - type: base
+      spec: "!icon/space_key_for_number_layout|!code/key_space"
+      attributes: { width: Grow, style: Spacebar, showPopup: false, longPressEnabled: true, moreKeyMode: OnlyExplicit, rowSpan: 2 }
+    - "@"
+    - ["#", "№"]
+    - "$"
+    - "("
+    - ")"
+    - "/"
+    - type: base
+      spec: "!icon/space_key_for_number_layout|!code/key_space"
+      attributes: { width: Grow, style: Spacebar, showPopup: false, longPressEnabled: true, moreKeyMode: OnlyExplicit, rowSpan: 2 }
+  - letters:
+    - type: gap
+      attributes: { width: Grow }
+    - "_"
+    - "&"
+    # U+2013: "–" EN DASH
+    # U+2014: "—" EM DASH
+    # U+207B: "⁻" SUPERSCRIPT MINUS
+    # U+208B: "₋" SUBSCRIPT MINUS
+    # U+00B7: "·" MIDDLE DOT
+    - ["-", "_", "\u2013", "\u2014", "\u207B", "\u208B", "\u00B7"]
+    # U+207A: "⁺" SUPERSCRIPT PLUS
+    # U+208A: "⁺" SUBSCRIPT PLUS
+    - ["+", "\u207A", "\u208A"]
+    - ":"
+    - ";"
+    - type: gap
+      attributes: { width: Grow }
+  - bottom:
+    - $alphabet
+    - type: contextual
+      fallbackKey:
+        type: base
+        spec: ","
+        attributes: { width: FunctionalKey, style: Normal, moreKeyMode: All }
+      attributes: { width: FunctionalKey, style: Normal, moreKeyMode: All }
+    - type: base
+      spec: "!icon/numpad|!code/key_to_number_layout"
+      attributes: { width: FunctionalKey, style: Normal, showPopup: false }
+    - type: base
+      spec: "*"
+      attributes: { width: FunctionalKey, style: Normal }
+    - type: base
+      spec: "\""
+      attributes: { width: FunctionalKey, style: Normal }
+    - type: base
+      spec: "'"
+      attributes: { width: FunctionalKey, style: Normal }
+    - type: base
+      spec: "."
+      attributes: { width: FunctionalKey, style: Normal, moreKeyMode: All }
+    - $enter

--- a/Default/clearflow_symbols.yaml
+++ b/Default/clearflow_symbols.yaml
@@ -2,6 +2,7 @@ name: "ClearFlow Symbols"
 numberRowMode: AlwaysDisabled
 bottomRowHeightMode: Flexible
 bottomRowWidthMode: Identical
+mirrorInOneHanded: true
 supportsSplit: false
 attributes:
   shiftable: false

--- a/Default/clearflow_symbols_shift.yaml
+++ b/Default/clearflow_symbols_shift.yaml
@@ -2,6 +2,7 @@ name: "ClearFlow Symbols (Shifted)"
 numberRowMode: AlwaysDisabled
 bottomRowHeightMode: Flexible
 bottomRowWidthMode: Identical
+mirrorInOneHanded: true
 supportsSplit: false
 attributes:
   shiftable: false

--- a/Default/clearflow_symbols_shift.yaml
+++ b/Default/clearflow_symbols_shift.yaml
@@ -1,0 +1,94 @@
+name: "ClearFlow Symbols (Shifted)"
+numberRowMode: AlwaysDisabled
+bottomRowHeightMode: Flexible
+bottomRowWidthMode: Identical
+attributes:
+  shiftable: false
+  moreKeyMode: OnlyFromLetter
+rows:
+  - letters:
+    - $shift
+    - "~"
+    - "`"
+    - "|"
+    # U+2022: "•" BULLET
+    - type: base
+      spec: "\u2022"
+      moreKeys: "!text/morekeys_bullet"
+    # U+221A: "√" SQUARE ROOT
+    - "\u221A"
+    # U+03C0: "π" GREEK SMALL LETTER PI
+    - type: base
+      spec: "\u03C0"
+      moreKeys: ["\u03A0", "μ", "Ω"]
+    - type: base
+      spec: "!icon/delete_key|!code/key_delete"
+      attributes: { width: FunctionalKey, style: Functional, anchored: true, showPopup: false, moreKeyMode: OnlyExplicit, repeatableEnabled: true, rowSpan: 2 }
+  - letters:
+    - type: base
+      spec: "!icon/action_switch_language|!code/action_switch_language"
+      attributes: { width: FunctionalKey, style: Functional, showPopup: false }
+    # U+00F7: "÷" DIVISION SIGN
+    - "\u00F7"
+    # U+00D7: "×" MULTIPLICATION SIGN
+    - "\u00D7"
+    # U+00B6: "¶" PILCROW SIGN
+    - type: base
+      spec: "\u00B6"
+      moreKeys: "\u00A7"
+    # U+2206: "∆" INCREMENT
+    - "\u2206"
+    - type: base
+      spec: "^"
+      moreKeys: "\u2191,\u2193,\u2190,\u2192"
+    # U+00B0: "°" DEGREE SIGN
+    - type: base
+      spec: "\u00B0"
+      moreKeys: "\u2032,\u2033"
+    - type: gap
+      attributes: { width: FunctionalKey }
+  - letters:
+    - type: base
+      spec: "!icon/space_key_for_number_layout|!code/key_space"
+      attributes: { width: Grow, style: Spacebar, showPopup: false, longPressEnabled: true, moreKeyMode: OnlyExplicit, rowSpan: 2 }
+    - "$currency1"
+    - "$currency2"
+    - "$currency3"
+    - "$currency4"
+    - "="
+    - "\\"
+    - type: base
+      spec: "!icon/space_key_for_number_layout|!code/key_space"
+      attributes: { width: Grow, style: Spacebar, showPopup: false, longPressEnabled: true, moreKeyMode: OnlyExplicit, rowSpan: 2 }
+  - letters:
+    - type: gap
+      attributes: { width: Grow }
+    - "!text/keyspec_left_curly_bracket"
+    - "!text/keyspec_right_curly_bracket"
+    - "%"
+    - "\u2713"
+    - "!text/keyspec_left_square_bracket"
+    - "!text/keyspec_right_square_bracket"
+    - type: gap
+      attributes: { width: Grow }
+  - bottom:
+    - $alphabet
+    - type: base
+      spec: "<"
+      attributes: { width: FunctionalKey, style: Normal }
+    - type: base
+      spec: "!icon/numpad|!code/key_to_number_layout"
+      attributes: { width: FunctionalKey, style: Normal, showPopup: false }
+    - type: base
+      spec: "\u00A9"
+      attributes: { width: FunctionalKey, style: Normal }
+    - type: base
+      spec: "\u00AE"
+      attributes: { width: FunctionalKey, style: Normal }
+    - type: base
+      spec: "\u2122"
+      attributes: { width: FunctionalKey, style: Normal }
+    - type: base
+      spec: ">"
+      attributes: { width: FunctionalKey, style: Normal }
+    - $enter

--- a/Default/clearflow_symbols_shift.yaml
+++ b/Default/clearflow_symbols_shift.yaml
@@ -2,6 +2,7 @@ name: "ClearFlow Symbols (Shifted)"
 numberRowMode: AlwaysDisabled
 bottomRowHeightMode: Flexible
 bottomRowWidthMode: Identical
+supportsSplit: false
 attributes:
   shiftable: false
   moreKeyMode: OnlyFromLetter

--- a/mapping.yaml
+++ b/mapping.yaml
@@ -14,6 +14,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   ak:
     - akan
   agx:
@@ -38,6 +39,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   ba:
     - bashkir
     - east_slavic
@@ -85,6 +87,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   ce:
     - north_caucasian
   ckb:
@@ -101,6 +104,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   cv:
     - chuvash
   cy:
@@ -116,6 +120,7 @@ languages:
     - colemak_dh_ansi
     - bepo
     - pcqwerty
+    - clearflow
   dar:
     - north_caucasian
   de:
@@ -131,6 +136,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   de_CH:
     - swiss
     - qwerty
@@ -143,6 +149,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   dz:
     - tibetan_wylie
   el:
@@ -157,6 +164,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   en_GB:
     - qwerty
     - qwertz
@@ -169,6 +177,7 @@ languages:
     - pcqwerty
     - nordic
     - workman
+    - clearflow
   en_IN:
     - qwerty
     - qwertz
@@ -181,6 +190,7 @@ languages:
     - pcqwerty
     - nordic
     - workman
+    - clearflow
   en_Shaw:
     - shavian
     - shavian_two_layer
@@ -196,6 +206,7 @@ languages:
     - pcqwerty
     - nordic
     - workman
+    - clearflow
   enf:
     - enets
   enh:
@@ -212,6 +223,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   es:
     - spanish
     - qwerty
@@ -236,6 +248,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   es_US:
     - spanish
     - qwerty
@@ -248,6 +261,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   et_EE:
     - estonian
     - nordic
@@ -260,6 +274,7 @@ languages:
     - colemak_dh_ansi
     - bepo
     - pcqwerty
+    - clearflow
   eu_ES:
     - spanish
     - qwerty
@@ -272,6 +287,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   fa:
     - farsi
   fi:
@@ -285,6 +301,7 @@ languages:
     - colemak_dh_ansi
     - bepo
     - pcqwerty
+    - clearflow
   fr:
     - azerty
     - swiss
@@ -300,6 +317,7 @@ languages:
     - nordic
     - azerty_inclusive
     - bepo_inclusive
+    - clearflow
   fr_CA:
     - qwerty
     - swiss
@@ -314,6 +332,7 @@ languages:
     - pcqwerty
     - nordic
     - bepo_inclusive
+    - clearflow
   fr_CH:
     - swiss
     - qwerty
@@ -328,6 +347,7 @@ languages:
     - pcqwerty
     - nordic
     - bepo_inclusive
+    - clearflow
   ga:
     - irish
   gag:
@@ -344,6 +364,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   ha:
     - hausa
   haw:
@@ -363,6 +384,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   hr:
     - serbian_qwertz
     - qwertz
@@ -376,6 +398,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   hu:
     - hungarian
     - qwertz
@@ -388,6 +411,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   hy_AM:
     - armenian_phonetic
   in:
@@ -401,6 +425,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   inh:
     - north_caucasian
   is:
@@ -415,6 +440,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   it:
     - qwerty
     - qwertz
@@ -426,6 +452,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   it_CH:
     - swiss
     - qwerty
@@ -438,6 +465,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   iw:
     - hebrew
     - hebrew-staggered
@@ -457,6 +485,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   ka_GE:
     - georgian
   kaa:
@@ -518,6 +547,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   lud:
     - ludic_veps
     - qwerty
@@ -532,6 +562,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   mhr:
     - mari_meadow
   mrj:
@@ -556,6 +587,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   mt:
     - maltese
     - qwerty
@@ -568,6 +600,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   my:
     - myanmar_g
   nb:
@@ -590,6 +623,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   nl_BE:
     - azerty
     - qwerty
@@ -601,6 +635,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   nio:
     - nganasan
   pa_IN:
@@ -616,6 +651,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   pt_BR:
     - spanish
     - qwerty
@@ -628,6 +664,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   pt_PT:
     - spanish
     - qwerty
@@ -640,6 +677,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   ro:
     - romanian
     - qwerty
@@ -652,6 +690,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   ru:
     - east_slavic
     - russian_student
@@ -688,6 +727,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   sl:
     - slovenian_qwerty
     - slovenian_qwertz
@@ -701,6 +741,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   sq:
     - albanian
     - qwertz
@@ -713,6 +754,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   sr:
     - south_slavic
   sr_Latn:
@@ -732,6 +774,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   ta_IN:
     - tamil_inscript
     - tamil
@@ -769,6 +812,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   tok:
     - toki_pona
   tr:
@@ -783,6 +827,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   tt:
     - tatar
   tyv:
@@ -809,6 +854,7 @@ languages:
   vi:
     - vietnamese_telex
     - vietnamese_vni
+    - clearflow
   vot:
     - votic
     - qwerty
@@ -841,6 +887,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   zz:
     - qwerty
     - qwertz
@@ -852,6 +899,7 @@ languages:
     - bepo
     - pcqwerty
     - nordic
+    - clearflow
   ja:
     - flick
     - japanese_qwerty


### PR DESCRIPTION
Add the ClearFlow keyboard layout, a high-performance layout optimized for swipe-typing accuracy and speed.

Layout features:
- 8-column grid with space keys spanning two rows (X-row and F-row) via rowSpan: 2, rendering as single tall keys on each side
- Custom symbols and shifted symbols layouts matching the same 8-column structure, with backspace also spanning two rows
- All bottom row keys use uniform FunctionalKey width
- Language switch, action, shift, and delete keys in standard positions

Files added:
- Default/clearflow.yaml (main alpha layout)
- Default/clearflow_symbols.yaml (numbers and punctuation)
- Default/clearflow_symbols_shift.yaml (math, currencies, brackets)
- mapping.yaml updated with ClearFlow entry

Fixes: #163

Requires:

- https://github.com/futo-org/android-keyboard/pull/1912
- https://github.com/futo-org/android-keyboard/pull/1914
- https://github.com/futo-org/android-keyboard/pull/1915
- https://github.com/futo-org/android-keyboard/pull/1926
- https://github.com/futo-org/android-keyboard/pull/1927