### PR TITLE
Added Ergo-L layouts

### DIFF
--- a/LatinScript/French/ergol.yaml
+++ b/LatinScript/French/ergol.yaml
@@ -1,0 +1,36 @@
+name: Ergo-L
+languages: ["fr", "en_GB", "en_IN", "en_US"]
+description: "Ergo-L layout for Futo Keyboard"
+numberRowMode: UserConfigurable
+rows:
+  - letters:
+    - [q, â]
+    - [c, ç]
+    - [o, œ]
+    - [p, ô]
+    - [w]
+    - [j]
+    - [m]
+    - [d]
+    - [y, û]
+  - letters:
+    - [a, à]
+    - [s, é]
+    - [e, è]
+    - [n, ê, ë]
+    - [f]
+    - [l]
+    - [r]
+    - [t, î]
+    - [i, ï]
+    - [u, ù]
+  - letters:
+    - $shift
+    - [z, æ]
+    - [x]
+    - [v]
+    - [b]
+    - [h]
+    - [g]
+    - [k]
+    - $delete

--- a/LatinScript/French/ergol_alt.yaml
+++ b/LatinScript/French/ergol_alt.yaml
@@ -1,0 +1,79 @@
+name: Ergo-L Full
+languages: ["fr", "en_GB", "en_IN", "en_US"]
+description: "Ergo-L full layout for Futo Keyboard"
+numberRowMode: UserConfigurable
+rows:
+  - numbers:
+    - type: case
+      normal: [1, "€", "„"]
+      shifted: [1, "„", "€"]
+    - type: case
+      normal: [2, "«", "‘", "“"]
+      shifted: [2, "‘", "«", "“"]
+    - type: case
+      normal: [3, "»", "’", "”"]
+      shifted: [3, "’", "»", "”"]
+    - [4, "$", "¢"]
+    - [5, "%|%", "‰"]
+    - [6, "^"]
+    - [7, "&"]
+    - [8, "*", "§"]
+    - [9, "#", "¶"]
+    - [0, "@", "°"]
+    - type: case
+      normal: ["=", "+", "±", "≠", "–", "÷"]
+      shifted: ["+", "=", "±", "≠", "–", "÷"]
+  - letters:
+    - [q, â, "^"]
+    - [c, ç, "<"]
+    - [o, œ, ">"]
+    - [p, ô, "$", "¤"]
+    - [w, "%|%"]
+    - [j, "@"]
+    - [m, "&", "µ"]
+    - [d, "*", "_"]
+    - [y, û, "`"]
+    - type: case
+      normal: ["'", "\"", "!", "¡"]
+      shifted: ["\"", "'", "!", "¡"]
+    - type: case
+      normal: ["{", "["]
+      shifted: ["[", "{"]
+  - letters:
+    - [a, à, "{"]
+    - [s, é, "("]
+    - [e, è, ")"]
+    - [n, ê, ë, "}"]
+    - [f, "ñ", "="]
+    - [l, "(", "\\"]
+    - [r, ")", "+"]
+    - [t, î, "-"]
+    - [i, "/", ï]
+    - [u, ù, "\""]
+    - type: case
+      normal: ["}", "]"]
+      shifted: ["]", "}"]
+  - letters:
+    - $shift
+    - [z, æ, "~"]
+    - [x, "\\", "[", ß, "‑"]
+    - [v, "|", "_", "]", "–"]
+    - [b, "#", "—"]
+    - [h, "!"]
+    - [g, ";"]
+    - [k, "?"]
+    - type: case
+      normal: ["-", "_", ":", "|", "…", "’"]
+      shifted: ["_", "-", ":", "|", "…", "’"]
+    - $delete
+  - bottom:
+    - $symbols
+    - type: contextual
+      fallbackKey: ","
+    - $action
+    - $space
+    - $number
+    - type: case
+      normal: [".", "'", "?", "-", "¿", ":", "|", ";"]
+      shifted: ["'", ".", "?", "-", "¿", ":", "|", ";"]
+    - $enter

--- a/mapping.yaml
+++ b/mapping.yaml
@@ -182,6 +182,8 @@ languages:
     - colemak_dh
     - colemak_dh_ansi
     - bepo
+    - ergol
+    - ergol_alt
     - pcqwerty
     - nordic
     - workman
@@ -196,6 +198,8 @@ languages:
     - colemak_dh
     - colemak_dh_ansi
     - bepo
+    - ergol
+    - ergol_alt
     - pcqwerty
     - nordic
     - workman
@@ -213,6 +217,8 @@ languages:
     - colemak_dh
     - colemak_dh_ansi
     - bepo
+    - ergol
+    - ergol_alt
     - pcqwerty
     - nordic
     - workman
@@ -330,6 +336,8 @@ languages:
     - colemak_dh_ansi
     - bepo
     - bepo_alt
+    - ergol
+    - ergol_alt
     - pcqwerty
     - nordic
     - azerty_inclusive
@@ -347,6 +355,8 @@ languages:
     - colemak_dh_ansi
     - bepo
     - bepo_alt
+    - ergol
+    - ergol_alt
     - pcqwerty
     - nordic
     - bepo_inclusive
@@ -363,6 +373,8 @@ languages:
     - colemak_dh_ansi
     - bepo
     - bepo_alt
+    - ergol
+    - ergol_alt
     - pcqwerty
     - nordic
     - bepo_inclusive


### PR DESCRIPTION
This pull requests adds the Ergo-L layout for French and English. Solves issue #289. See https://ergol.org/ for more information about this layout.

It's a nice alternative to BEPO keyboard, adapted to developers, and can be used for both French and English languages.

Two variants:
- ergol: a simple layout with only the letter parts of the Ergo-L layout, adapted to smaller screens or people who don't code.
  <img width="256" height="240" alt="ergol" src="https://github.com/user-attachments/assets/df77fb83-aba5-4ae7-8b38-88676cdff216" />
- ergol_alt: a variant closer to the full Ergo-L keyboard layout. All the common characters for programming are easy to access, making this layout very convenient to code on device. It also features an improved number row with the same bindings as the original desktop Ergo-L layout. Some changes have been made to make certain characters easier to access than in the original layout, due to limited mobile screen space.
  <img width="256" height="240" alt="ergol_alt" src="https://github.com/user-attachments/assets/214b9b95-1368-4484-84ba-feb9f3c7c659" />

