### PR TITLE
Improve Chinese QWERTY layout with tone marks and extra punctuation

### DIFF
--- a/Chinese/zh_qwerty.yaml
+++ b/Chinese/zh_qwerty.yaml
@@ -7,7 +7,7 @@ rows:
   - letters:
     - ['q', '!fixedColumnOrder!3', '1', '~', '～', '`', '·']
     - ['w', '!fixedColumnOrder!3', '2', '@', '·']
-    - ['e', '!fixedColumnOrder!3', '3', '#']
+    - ['e', '!fixedColumnOrder!3', '3', '#', 'ē', 'é', 'ě', 'è']
     - ['r', '!fixedColumnOrder!3', '4', '$', '￥']
     - ['t', '!fixedColumnOrder!3', '5', '%|%']
     - ['y', '!fixedColumnOrder!3', '6', '^']

--- a/Chinese/zh_qwerty.yaml
+++ b/Chinese/zh_qwerty.yaml
@@ -5,18 +5,18 @@ autoShift: false
 imeHint: "qwerty"
 rows:
   - letters:
-    - ['q', '!fixedColumnOrder!3', '1', '~', '`']
-    - ['w', '!fixedColumnOrder!3', '2', '@']
+    - ['q', '!fixedColumnOrder!3', '1', '~', '～', '`', '·']
+    - ['w', '!fixedColumnOrder!3', '2', '@', '·']
     - ['e', '!fixedColumnOrder!3', '3', '#']
     - ['r', '!fixedColumnOrder!3', '4', '$', '￥']
     - ['t', '!fixedColumnOrder!3', '5', '%|%']
     - ['y', '!fixedColumnOrder!3', '6', '^']
-    - ['u', '!fixedColumnOrder!3', '7', '&']
-    - ['i', '!fixedColumnOrder!3', '8', '*']
-    - ['o', '!fixedColumnOrder!3', '9', '(']
+    - ['u', '!fixedColumnOrder!3', '7', '&', 'ū', 'ú', 'ǔ', 'ù']
+    - ['i', '!fixedColumnOrder!3', '8', '*', 'ī', 'í', 'ǐ', 'ì']
+    - ['o', '!fixedColumnOrder!3', '9', '(', 'ō', 'ó', 'ǒ', 'ò']
     - ['p', '!fixedColumnOrder!3', '0', ')']
   - letters:
-    - ['a', '!fixedColumnOrder!3', '？', '?']
+    - ['a', '!fixedColumnOrder!3', '？', '?', 'ā', 'á', 'ǎ', 'à']
     - ['s', '!fixedColumnOrder!3', '！', '!']
     - ['d', '!fixedColumnOrder!3', '；', ';']
     - ['f', '!fixedColumnOrder!3', '：', ':']
@@ -30,7 +30,7 @@ rows:
     - ['z', '!fixedColumnOrder!3', '"', '「', '」']
     - ['x', '!fixedColumnOrder!3', '''', '『', '』']
     - ['c', '!fixedColumnOrder!3', '-', '_']
-    - ['v', '!fixedColumnOrder!3', '=', '+']
+    - ['v', '!fixedColumnOrder!3', '=', '+', 'ü', 'ǖ', 'ǘ', 'ǚ', 'ǜ']
     - ['b', '!fixedColumnOrder!3', '<', '《', '〈']
     - ['n', '!fixedColumnOrder!3', '>', '》', '〉']
     - ['m', '!fixedColumnOrder!3', '/', '\', '|']
@@ -42,6 +42,6 @@ rows:
     - $space
     - type: base
       spec: '。'
-      moreKeys: ['…|……', '？', '！', '；', '：', '—|——']
+      moreKeys: ['…|……', '？', '！', '；', '：', '—|——', '·', '～']
       attributes: { moreKeyMode: OnlyExplicit }
     - $enter


### PR DESCRIPTION
This commit adds several quality of life improvements for the Chinese QWERTY layout:
- Added standard Pinyin tone marks to long-press vowels (a, e, i, o, u). Also adds standard ü variations to the v, as is standard in Chinese keyboards. 
- Added the middle dot (·) to the q, w, and period keys, as it is used to separate first and last names in Chinese-transliterated foreign names.
- Added the full-width tilde (～) to the q and period keys, as unlike the standard tilde (~) it is heavily used in Chinese internet slang and texting to indicate a trailing, playful tone (e.g., 你好～)

Note: The middle dot (·) and full-width tilde (～) are added not only to the period key, but also to the `q` and `w` keys. This mirrors standard PC muscle memory (where these symbols map to the ` and @ keys) and provides a much faster, less crowded swipe target than relying solely on the period key's popup menu.