### PR TITLE
Add Polski / English (typograficzna): one layout for Polish and English

### DIFF
--- a/Default/polish_english_typographic.yaml
+++ b/Default/polish_english_typographic.yaml
@@ -1,0 +1,96 @@
+# Polski / English (typograficzna)
+# Contributed by Andrei Kirkouski; notes and the desktop layouts
+# this follows are at https://polish-typographic.com
+
+name: "Polski / English (typograficzna)"
+description: "Polish and English on one layout, with dead-key accents and the typographic characters the stock symbols pages lack."
+languages: pl en_US
+combiners:
+  - DeadKeyPreCombiner
+  - DeadKey
+mirrorInOneHanded: true
+rows:
+  - letters:
+      - "q"
+      - "w"
+      - {type: base, spec: "e", moreKeys: ["ę"], hint: "ę"}
+      - "r"
+      - "t"
+      - "y"
+      - "u"
+      - "i"
+      - {type: base, spec: "o", moreKeys: ["ó"], hint: "ó"}
+      - "p"
+  - letters:
+      - {type: base, spec: "a", moreKeys: ["ą"], hint: "ą"}
+      - {type: base, spec: "s", moreKeys: ["ś", "ß"], hint: "ś"}
+      - "d"
+      - "f"
+      - "g"
+      - "h"
+      - "j"
+      - "k"
+      - {type: base, spec: "l", moreKeys: ["ł"], hint: "ł"}
+  - letters:
+      - $shift
+      - {type: base, spec: "z", moreKeys: ["ż", "ź"], hint: "ż"}
+      - "x"
+      - {type: base, spec: "c", moreKeys: ["ć"], hint: "ć"}
+      - "v"
+      - "b"
+      - {type: base, spec: "n", moreKeys: ["ń"], hint: "ń"}
+      - "m"
+      - $delete
+  - bottom:
+      - $symbols
+      - {type: contextual, fallbackKey: ","}
+      - $action
+      - $space
+      - {type: base, spec: "⁜|!code/key_to_alt_0_layout", attributes: {width: Regular, style: Functional, showPopup: false, moreKeyMode: OnlyExplicit}} # U+205C DOTTED CROSS, switches to the alt page
+      - $period
+      - $enter
+altPages:
+  - - attributes: {moreKeyMode: OnlyExplicit}
+      letters:
+        - "`|\u0300" # dead grave
+        - "´|\u0301" # dead acute
+        - "ˆ|\u0302" # dead circumflex
+        - "˜|\u0303" # dead tilde
+        - "˘|\u0306" # dead breve
+        - "¨|\u0308" # dead diaeresis
+        - "˚|\u030A" # dead ring
+        - "˝|\u030B" # dead double-acute
+        - "ˇ|\u030C" # dead caron
+        - "¸|\u0327" # dead cedilla
+    - attributes: {moreKeyMode: OnlyExplicit}
+      letters:
+        - {type: base, spec: "⍽|\u00A0", hint: "nbsp"} # NO-BREAK SPACE
+        - "✓" # CHECK MARK
+        - "−" # MINUS SIGN
+        - "⌀" # DIAMETER SIGN
+        - "⌃" # UP ARROWHEAD
+        - $gap
+        - $gap
+        - $gap
+        - $gap
+        - $gap
+    - attributes: {moreKeyMode: OnlyExplicit}
+      letters:
+        - {type: base, spec: "⍽|\u202F", hint: "nnbsp"} # NARROW NO-BREAK SPACE
+        - {type: base, spec: "␣|\u2009", hint: "thin"} # THIN SPACE
+        - {type: base, spec: "‧|\u00AD", hint: "shy"} # SOFT HYPHEN
+        - {type: base, spec: "‑|\u2011", hint: "nbhy"} # NON-BREAKING HYPHEN
+        - $gap
+        - $gap
+        - $gap
+        - $gap
+        - $gap
+        - $delete
+    - bottom:
+        - $symbols
+        - {type: contextual, fallbackKey: ","}
+        - $action
+        - $space
+        - {type: base, spec: "⁜|!code/key_to_alt_0_layout", attributes: {width: Regular, style: Functional, showPopup: false, moreKeyMode: OnlyExplicit}} # U+205C DOTTED CROSS, switches to the alt page
+        - $period
+        - $enter

--- a/mapping.yaml
+++ b/mapping.yaml
@@ -187,6 +187,7 @@ languages:
     - workman
     - kasroz
     - clearflow
+    - polish_english_typographic
   en_IN:
     - qwerty
     - qwertz
@@ -201,6 +202,7 @@ languages:
     - workman
     - kasroz
     - clearflow
+    - polish_english_typographic
   en_Shaw:
     - shavian
     - shavian_two_layer
@@ -218,6 +220,7 @@ languages:
     - workman
     - kasroz
     - clearflow
+    - polish_english_typographic
   enf:
     - enets
   enh:
@@ -690,6 +693,7 @@ languages:
     - nordic
     - kasroz
     - clearflow
+    - polish_english_typographic
   pt_BR:
     - spanish
     - qwerty


### PR DESCRIPTION
Adds `Default/polish_english_typographic.yaml`, one layout carrying Polish and English together so a bilingual typist keeps a single subtype for both. Listed in `mapping.yaml` under `pl`, `en_GB`, `en_IN` and `en_US` — the three English locales carry byte-identical layout lists, as every other `Default/` layout does.

### Placement

Polish letters sit on the base letter a Polish typist reaches for: `a` carries `ą`, `z` carries `ż` and `ź`. Their desktop AltGr positions mean nothing on a phone, so they are not reproduced.

Every key that gains a Polish letter names one of them in an explicit `hint:`. With `KeyHintsSetting` off, which is the default, a key shows only what its grid position gives it and never a letter from its own `moreKeys`, so the added letter would never appear. The cost is the digit that position would otherwise put there: `e` and `o` are in the top row, so on a fresh install they stop showing `3` and `9` in the corner. Both digits are still on the long press, and the six hints on the lower rows cost nothing, since those rows inherit symbols rather than digits. Explicit hints on letter keys are rare: among alphabet layouts only `toki_pona` and `uyghur` use them, `toki_pona` on a single key and `uyghur` on two. This layout does it on eight.

Where a key gains two letters the hinted one leads its `moreKeys` and the second follows, so `ż` is hinted on `z` and `ź` sits behind it. `s` is the other two-letter key: its second letter is `ß`, which the desktop layout carries on AltGr+B and the generator places on the base letter like everything else. It is not a Polish letter, and stock already offers it behind `s` through `MiscLetters` on both `pl` and `en_US`, so the explicit entry only guarantees it for someone who has removed `MiscLetters` from the long press order.

Hints are not case mapped. The keycap follows the shift state and the hint does not, so a field that opens with auto-capitalization shows `E` over a lowercase `ę`. The popup does follow the shift state, so selecting `ę` from it gives `Ę`.

`moreKeys` prepends, so stock's own entries stay on the key. On an `en_US` subtype, long pressing `e` gives `ę` as the highlighted default, then `3` when the number row is off, then the accented set stock already offers: `é è ê ë ē`.

On a `pl` subtype the same letters arrive twice, once from this layout and once from `pl.json` via `LanguageKeys`, and `MoreKeysBuilder` concatenates without deduplicating. They do not reach the popup twice: `LayoutEngine.build` calls `removeRedundantMoreKeys()` before it returns, and its `removeDuplicateMoreKeys` drops a spec that repeats an earlier one in the list, and separately one whose code equals the key's own. Checked on a `pl` subtype: long pressing `e` gives `ę` once, then `3`, then six accented forms — those six arrive from `pl.json`'s `misc_e` through **MiscLetters**, not through the `LanguageKeys` route this paragraph is about, whose `e` entry is the single `ę`.

So the explicit `moreKeys` are what put eight of the nine Polish letters on `en_US`, where `pl.json` is never consulted, and are absorbed on `pl`. `ó` is the exception, alongside the non-Polish `ß`: `DEFAULT.json`'s `misc_o` already leads with it, so there the explicit entry buys the hint and the highlighted position rather than the letter.

### Symbols pages and the alt page

This layout overrides no symbols page. Every non-letter character it carries that stock already has a home for, on a symbols page or behind a long press, is left to stock: no `layoutSetOverrides`, no forked `Special/symbols*.yaml`.

What the default symbols pages have nowhere goes on one alt page: the ten dead keys, `−` `⌀` `⌃` `✓`, and five spacing and hyphenation characters (NBSP, narrow NBSP, thin space, soft hyphen, non-breaking hyphen).

Those two groups are not equally strong claims, so to be precise about it — I searched every layout file, every locale JSON and both escaped and literal forms:

* The five spacing and hyphenation characters appear **nowhere in this repository**, in any form. That is the part of this page I would defend hardest.
* `⌀` U+2300 is likewise absent, though `DEFAULT.json`'s `morekeys_symbols_0` offers `∅` U+2205 EMPTY SET on the symbols page, which is a near-identical glyph with a different meaning.
* `✓` U+2713 **is** a keycap on `Default/clearflow_symbols_shift.yaml`, and `−` U+2212 is a long press in `ArabicScript/lulua.yaml`. Both are therefore already reachable for someone using those layouts — just not from the pages a `Default/` layout inherits. `⌃` U+2303 is absent everywhere.

Four of the five spacing characters print no glyph at all, and two of those draw the same stand-in; the fifth, the non-breaking hyphen, prints but is indistinguishable from an ordinary hyphen. So each carries hint text naming it. Dead keys work through `DeadKeyPreCombiner`, which promotes U+0300 to U+035B to a dead key event; NFC composes from there.

Each short row on that page is padded out to the dead-key row's width with `$gap`. Without it a letter row is centered on its own content, so a five-key row and a four-key row start at different offsets, and `$delete` is anchored, which pulls the last row's keys over to sit beside it at the right edge; the three rows then step raggedly across the page. The padding pins them to one grid: characters on the left under the dead keys above them, and `$delete` alone at the right.

The page ends its last letter row with `$delete`, as all six stock `altPages` layouts do, at the right edge where the letters page keeps its backspace. There is no shift, and the page is not locked: pressing a character returns you to the letters page, and so does delete. That is right for the ten dead keys and costs a second press per character for the nine others. (One exception, which I found reading `KeyboardState`: with auto-caps active the page does not switch back.)

### Bottom row

Stock's bottom row, slot for slot, except the optional ZWNJ position, which the alt page key occupies. The comma slot is `{type: contextual, fallbackKey: ","}`, which is the scalar shortcut `LayoutSpec.md` prints for the default bottom row; `DefaultBottomRow` builds the same object in Kotlin as `ContextualKey(fallbackKey = BaseKey(","))`. `$space` is `Grow`, so on stock the empty ZWNJ slot goes to the spacebar; putting a real key there makes the spacebar one key narrower. That key carries U+205C DOTTED CROSS, named in a comment on the line, since the stock `$alt0` template would render it as the digit `0`. `$action`, the contextual comma and `$period` are kept as template keys rather than literals; #311 documents what each of them carries and what replacing it costs.

The layout also sets `mirrorInOneHanded: true`, as `clearflow` and `kasroz` already do. In left-handed one-hand mode each row's leading and trailing anchored keys swap sides. On the alt page that moves `$delete` from the right edge to the left of its row and leaves the `$gap` padding where it is, because a `$gap` in a layout file becomes a `Key` with empty data — dropped at `LayoutEngine.computedKeyToKey` — rather than a `LayoutEntry.Gap`, and only the latter counts as outer to `swapOuterKeys`. Checked on a device rather than reasoned about, because reading the code alone predicted the opposite.

### Two dead key edge cases

NFC reproduces 177 of the 179 dead key compositions the desktop Polish layout defines. Counted one pair per dead key and base letter, leaving out space terminators, counting states that share a terminator once, and leaving out the eight pairs whose desktop output is more than a single codepoint (those have no precomposed form and the desktop table stores them decomposed). The two it misses are `B`+acute and `b`+acute, which the desktop table maps to `Ḿ`/`ḿ`; NFC gives `B́`/`b́`, which is the more defensible result.

A dead key followed by a space emits the bare combining mark (U+030C for caron) instead of a spacing modifier (U+02C7). That is `DeadKeyCombiner`'s whitespace branch, which outputs the pending dead sequence as-is, so it is what `irish`, `hawaiian` and `lakota` already do. Changing it would be a `DeadKeyCombiner` change rather than a layout one.

### Testing

On a device, and on an emulator at `b345f519e` plus one unrelated local commit:

- Split keyboard in landscape
- Number row enabled and disabled
- Arrow keys enabled and disabled
- Long-press key ordering changed from the default
- Action key and contextual key
- Left-handed one-handed mode, on the letters page and both alt page rows that carry padding

Also checked: on an `en_US` subtype all eight hints render and the `e` popup carries the set listed above; the symbols pages are unchanged; every character on the alt page emits the expected codepoint; and six of the ten dead keys compose against real bases (`´`+o to `ó`, `ˇ`+c to `č`, `¸`+c to `ç`, `˝`+o to `ő`, `˘`+a to `ă`, `¨`+u to `ü`). The other four, grave, circumflex, tilde and ring, are the same code path and were not exercised individually.

The letters page and the alt page, in both themes, are at https://polish-typographic.com/android.

### Gesture typing

FUTO ships no Polish dictionary, and the suggestion strip on a `pl` subtype offers to download one, so a `pl` subtype cannot swipe until that download or a manual import completes. One dictionary containing both languages should then let a single subtype swipe in either, but I have not built one, so that part is untested.

### Three things I would rather you decide

* **Directory.** It is in `Default/` because it is offered to all three English locales as a qwerty variant, which is that directory's population — `nordic` has the same shape, registered for the three English locales plus the Nordic ones. If you would rather group it with the language-specific Latin layouts in `LatinScript/`, say so and I will move it.
* **Name.** `Polski / English (typograficzna)` is the only non-English entry an `en_US` user will see in the layout list. It is bilingual on purpose, but "typograficzna" is opaque to the English half of its audience; I will rename it if you prefer.
* **Ownership.** The file is generated, but the in-tree copy is canonical once merged. If you edit it here I will hand-port the change back rather than regenerate over you.

Sibling PR #310 adds the Cyrillic layout; #311 documents the `altPages`, `$alt0` and template-key behaviour both of them rely on. They are independent — nothing here needs #311 merged — but #311 is where a reviewer will find the reasoning for the alt page's shape.

Generated from https://polish-typographic.com
