### PR TITLE
Add Кириллица (типографская): one Cyrillic layout for ru, be and uk

### DIFF
--- a/Cyrillic/cyrillic_typographic.yaml
+++ b/Cyrillic/cyrillic_typographic.yaml
@@ -1,0 +1,102 @@
+# Кириллица (типографская)
+# Contributed by Andrei Kirkouski; notes and the desktop layouts
+# this follows are at https://polish-typographic.com
+
+name: "Кириллица (типографская)"
+description: "Russian, Belarusian and Ukrainian on one layout, the extra letters behind their base letter, with dead-key accents."
+languages: ru be uk
+combiners:
+  - DeadKeyPreCombiner
+  - DeadKey
+mirrorInOneHanded: true
+rows:
+  - letters:
+      - "й"
+      - "ц"
+      - {type: base, spec: "у", moreKeys: ["ў"], hint: "ў"}
+      - "к"
+      - {type: base, spec: "е", moreKeys: ["ё", "є"], hint: "ё"}
+      - "н"
+      - {type: base, spec: "г", moreKeys: ["ґ"], hint: "ґ"}
+      - "ш"
+      - {type: base, spec: "щ", moreKeys: ["щ"]} # keeps щ reachable where KeySpecShortcuts replaces this keycap; dedup drops it elsewhere
+      - "з"
+      - {type: base, spec: "х", moreKeys: ["’", "'"], hint: "’"}
+      - "ъ"
+  - letters:
+      - "ф"
+      - {type: base, spec: "ы", moreKeys: ["ы"]} # keeps ы reachable where KeySpecShortcuts replaces this keycap; dedup drops it elsewhere
+      - "в"
+      - "а"
+      - "п"
+      - "р"
+      - "о"
+      - "л"
+      - "д"
+      - "ж"
+      - {type: base, spec: "э", moreKeys: ["э"]} # keeps э reachable where KeySpecShortcuts replaces this keycap; dedup drops it elsewhere
+  - letters:
+      - $shift
+      - "я"
+      - "ч"
+      - "с"
+      - "м"
+      - {type: base, spec: "и", moreKeys: ["ї", "і", "и"], hint: "ї"} # keeps и reachable where KeySpecShortcuts replaces this keycap; dedup drops it elsewhere
+      - "т"
+      - "ь"
+      - "б"
+      - "ю"
+      - $delete
+  - bottom:
+      - $symbols
+      - {type: contextual, fallbackKey: ","}
+      - $action
+      - $space
+      - {type: base, spec: "⁜|!code/key_to_alt_0_layout", attributes: {width: Regular, style: Functional, showPopup: false, moreKeyMode: OnlyExplicit}} # U+205C DOTTED CROSS, switches to the alt page
+      - $period
+      - $enter
+altPages:
+  - - attributes: {moreKeyMode: OnlyExplicit}
+      letters:
+        - "`|\u0300" # dead grave
+        - "´|\u0301" # dead acute
+        - "ˆ|\u0302" # dead circumflex
+        - "˜|\u0303" # dead tilde
+        - "˘|\u0306" # dead breve
+        - "¨|\u0308" # dead diaeresis
+        - "˚|\u030A" # dead ring
+        - "˝|\u030B" # dead double-acute
+        - "ˇ|\u030C" # dead caron
+        - "¸|\u0327" # dead cedilla
+    - attributes: {moreKeyMode: OnlyExplicit}
+      letters:
+        - {type: base, spec: "⍽|\u00A0", hint: "nbsp"} # NO-BREAK SPACE
+        - "₽" # RUBLE SIGN
+        - "✓" # CHECK MARK
+        - "₴" # HRYVNIA SIGN
+        - "−" # MINUS SIGN
+        - "⌀" # DIAMETER SIGN
+        - $gap
+        - $gap
+        - $gap
+        - $gap
+    - attributes: {moreKeyMode: OnlyExplicit}
+      letters:
+        - "⌃" # UP ARROWHEAD
+        - {type: base, spec: "⍽|\u202F", hint: "nnbsp"} # NARROW NO-BREAK SPACE
+        - {type: base, spec: "␣|\u2009", hint: "thin"} # THIN SPACE
+        - {type: base, spec: "‧|\u00AD", hint: "shy"} # SOFT HYPHEN
+        - {type: base, spec: "‑|\u2011", hint: "nbhy"} # NON-BREAKING HYPHEN
+        - $gap
+        - $gap
+        - $gap
+        - $gap
+        - $delete
+    - bottom:
+        - $symbols
+        - {type: contextual, fallbackKey: ","}
+        - $action
+        - $space
+        - {type: base, spec: "⁜|!code/key_to_alt_0_layout", attributes: {width: Regular, style: Functional, showPopup: false, moreKeyMode: OnlyExplicit}} # U+205C DOTTED CROSS, switches to the alt page
+        - $period
+        - $enter

--- a/mapping.yaml
+++ b/mapping.yaml
@@ -737,6 +737,7 @@ languages:
     - russian_student
     - russian_yavert
     - russian_yazhert
+    - cyrillic_typographic
   rut:
     - north_caucasian
   sah:


### PR DESCRIPTION
Adds `Cyrillic/cyrillic_typographic.yaml`, one Cyrillic layout covering Russian, Belarusian and Ukrainian. Listed in `mapping.yaml` under `ru` only, for the reason under "`be_BY` and `uk` are held back" below. The layout's own `languages: ru be uk` is not registration: `LayoutManager.kt:53` reads `mapping.yaml`, and that field is only read by `KeyboardLayoutPreview` and `DevLayoutList`.

Sibling of #309: same generator, same bottom row, same alt page approach, same dead-key mechanism, so this description covers only what differs. Separate PR to keep each reviewable.

### Placement

The `be_BY` and `uk` behavior described here is read off `be.json`, `uk.json` and `KeySpecShortcuts`, not observed: on this build futo-org/android-keyboard#2268 stops both this layout and stock `belarusian` from loading on those subtypes. The `ru` behavior described here was checked on an emulator.

Every letter this layout adds sits behind the letter it is a variant of: `ў` behind `у`, `є` behind `е`, `і` and `ї` behind `и`, `ґ` behind `г`. That is what lets one layout serve all three languages: on a `ru` subtype a Ukrainian `є` is still two presses away. All five are long presses there. On `be_BY` two of them also become keycaps, `ў` and `і`, and on `uk` two do, `і` and `є`. `ё` is written out on `е` as well, but stock already puts it there on `ru`, so it is not one of the five.

Stock's per-language layouts take a different route: a language's extra letter takes over whichever physical key the standard Russian layout was using, keycap and all. `belarusian.yaml` line 14 is `['ў', 'щ']`, so `ў` *is* the key and `щ` moves behind it; line 35 is `['і', 'и', 'ї']`. `ukrainian.yaml` does the same with `є` on Russian's `э` key and `і` on `ы`, and puts `ї` in the bottom row comma slot. `ґ` and `ї` are the two letters stock also hangs off their base, both in `belarusian.yaml`: `['г', 'ґ']`, and the `і` entry above.

This layout inherits that substitution rather than opting out of it: `useKeySpecShortcut` defaults to true, so `KeySpecShortcuts` resolves `щ`, `ы`, `э` and `и` per subtype. On `be_BY` the `щ` key becomes `ў` and `и` becomes `і`; on `uk`, `ы` becomes `і` and `э` becomes `є`. Belarusian has neither `щ` nor `и`, and Ukrainian has neither `ы` nor `э`, so the substitution gives the right keycap in all four cases.

The substitution does not rehome the letter it displaced. For `щ` the shortcut list is a single element, so `getDefaultMoreKeysForKey`'s `subList(1, size)` contributes nothing and `щ` would be reachable nowhere on `be_BY`. That is why stock writes the pair out as `['ў', 'щ']`. This layout names each of the four letters in its own `moreKeys` instead. Where the keycap is unchanged the entry matches the base code and `MoreKeySpec.removeDuplicateMoreKeys` drops it, so a `ru` subtype sees none of the four, and `be_BY` and `uk` see only the two the substitution touched. Where the base did change, the entry survives and carries the displaced letter. On `uk` that leaves `ы` behind `і`. Ukrainian does not use it, and it is kept on purpose: the point of one layout is that a Russian speaker on a `uk` subtype still has it.

Those four entries repeat their own key's `spec`, which read as YAML alone is indistinguishable from a copy-paste error, since the reason lives in `KeySpecShortcuts` rather than on the page. Each carries a comment on the line saying so.

Keys with more than one added letter follow #309, hinted letter first: `е` hints `ё` with `є` behind it, and `и` hints `ї` with `і` behind it and the displaced `и` last. There is one hint slot per keycap, and on `е` the Russian letter takes it since the layout ships for `ru` first. On `и` that hint is `ї`, not `і`: on `be_BY` `KeySpecShortcuts` turns this very key into `і`, and `LayoutEngine`'s explicit hint branch returns `data.hint` without comparing it against the label, so hinting `і` would print it twice there.

### Row widths and what the hints cost

The letter rows are 12 / 11 / 9. The top row keeps `ъ`, where stock's `east_slavic` is 11 wide and reaches `ъ` behind `ь`. Twelve matches the physical Russian keyboard, whose top row is ЙЦУКЕНГШЩЗХЪ. It is not free:

- Row 0 is centered against ten digits, so at twelve columns the offset is 1 and the two outer keys, `й` and `ъ`, get no digit, no symbol and no quick action.
- Four of the ten digits are displaced by hints: `у`, `е`, `г` and `х` show `ў ё ґ ’` instead of `2 4 6 0`. The number row is the way to all ten regardless, and the explicit hint takes the corner outright: with `KeyHintsSetting` off, which is the default, nothing else appears there.
- `ъ` is reachable behind `ь` on all three languages anyway (`cyrillic_soft_sign` on `ru` and `be`, `misc_code_u044c` on `uk`), so it is now reachable twice.

Dropping `ъ` for an 11-wide row is a one-line change if you would rather have the stock shape. It would drop the row 0 half of futo-org/android-keyboard#2263 below, but not the row 2 half, which follows from that row's own 9-wide width and is untouched by anything done to row 0.

For comparison, #309's Latin layout is 10 / 9 / 7 with eight hints, of which only two sit on row 0, so it gives up `3` and `9` and nothing else.

### The apostrophe

Belarusian and Ukrainian spell with one (аб’ява, п’ять, з’їзд), so here it behaves like a letter rather than punctuation. Stock gives it a home on the letters page: `belarusian.yaml` line 16 is `['х', '’']` and line 46 is a whole quote key in the bottom row; `ukrainian.yaml` line 13 keycaps the ASCII form, and `ukrainian_g.yaml` line 17 gives it its own key. This layout's bottom row has no free slot, since the alt page key took the optional ZWNJ position, so both forms hang off `х`, where Belarusian stock already puts one. U+2019 leads and is hinted, since that is the character both orthographies call for; ASCII U+0027 sits behind it, because that is what stock Ukrainian keycaps.

ASCII `'` is also the first Symbols long press on `м` on all three subtypes, so this adds a second route to it rather than a first.

### Dead keys reproduce less of the desktop table here

Dead keys work as in #309, and NFC reproduces 39 of the 57 compositions the desktop Russian layout defines, against 177 of 179 there. That figure is computed from the composition tables and NFC, not observed on a device; #309's 177 of 179 is backed by six dead keys composed against real bases. Counted the same way: one pair per dead key and base letter, leaving out space terminators, counting states that share a terminator once, and leaving out pairs whose desktop output is more than a single codepoint (one here — `э` + diaeresis, stored decomposed rather than as U+04ED — against eight there). The 18 it misses fall into three groups:

- 12 where the base already carries a diacritic and the desktop table *replaces* it while NFC *stacks* a second one: `Й`+breve gives `Й̆` rather than `Й`, `Ё`+grave gives `Ё̀` rather than `Ѐ`.
- 4 where cedilla maps to a Bashkir descender letter (`З`→`Ҙ`, `С`→`Ҫ` and lowercase). Those have no canonical decomposition, so NFC cannot produce them.
- 2 where NFC is arguably the better answer: the desktop table sends `у`+diaeresis to Latin `ÿ` and `і`+diaeresis to Latin `ï`, where NFC gives the Cyrillic `ӱ` and `ї`.

Neither of the first two groups arises in ordinary Russian, Belarusian or Ukrainian text.

### Alt page

Same as #309, plus `₽` and `₴`. Its short rows are padded to the dead-key row's width with `$gap` for the same reason, and it behaves the same way: not locked, so a character that is not a dead key costs a second press to get back to the letters page. Eleven characters here are not dead keys, against nine there, so that cost lands a little more often.

`₽` and `₴` are the one exception to the "leave stock's characters to stock" rule the rest of the page follows: the symbols page's `$` key is `keyspec_currency`, which resolves per subtype to `₴` on `uk` (from `uk.json`) and `₽` on `ru` and `be_BY` (from `CurrencyResolver`). Each subtype reaches one and not the other. Putting both on the alt page costs a duplicate for the matching subtype and makes both reachable on all three.

### `be_BY` and `uk` are held back

On this build the layout does not load on either, and neither do stock's own layouts for those languages. I filed futo-org/android-keyboard#2268 after reproducing it with `belarusian.yaml`. `b345f519e` renamed the `morekeys` entry `cyrillic_ie` to `code_u0435` in `ru.json` and in none of the other six locale files that define it. That left the new name defined by one locale, which places it past the end of `TEXTS_DEFAULT`, so `getText` throws for every locale but `ru`. It is three commits past the 0.1.30 tag and unreleased, so a released build is unaffected.

A `be_BY` user does not get a degraded keyboard. They get no keyboard: the layout error screen over a SWITCH LANGUAGE button. So this PR registers `ru` only.

There is no branch for that fix, because it is a one-line addition to `DEFAULT.json` and the issue argues at some length against the tempting alternative of finishing the rename. **I will open that PR if you want it** — or take the diff straight from the issue. Either candidate fix works for this layout: all it needs is for `morekeys_code_u0435` to resolve on `be` and `uk`. Once it lands, adding the two `mapping.yaml` rows is a two-line follow-up.

Swipe is a separate gap that #2268 does not close: no Belarusian or Ukrainian dictionary ships, so those subtypes will need a download or a manual import before they can gesture type. That is not why they are held back, though: #309 registers `pl` with the same gap. Russian has a bundled dictionary and works out of the box.

### A second upstream bug this layout runs into

Rows 0 and 2 meet futo-org/android-keyboard#2263: `actionForCoord` indexes `QwertySymbols` with a raw column while `symsForCoord` centers, so quick actions land one key off. `DEFAULT.json` gives an action to six qwerty positions only, five of them on rows 0 and 2, so the visible effect here is redo on `н` instead of `г` in row 0, and undo, cut, copy and paste each one key left in row 2. Row 1 carries the sixth, select all, and is unaffected, because 11 against a 10-wide reference truncates to an offset of zero. This is not specific to this layout. `east_slavic`, `belarusian` and `ukrainian` are all 11/11/9 and have the row 2 half today, on default settings, in the shipped release. The qwerty-shaped layouts are exempt because their third letter row is 7 wide, which is why it went unnoticed; other Latin layouts, `turkish` among them, are affected. I verified it on an emulator with this layout. A fix is on a branch linked from that issue.

### Testing

On an emulator at `b345f519e` plus one unrelated local commit, on a Russian subtype: the layout loads and is offered for `ru`, the five keys carrying an explicit hint read `ў ё ґ ’ ї`, the symbols pages are unchanged, every alt page keycap renders and emits the expected codepoint, and gesture typing works against the bundled Russian dictionary with no extra setup. Switching to a `be_BY` subtype reproduces futo-org/android-keyboard#2268 for this layout and for stock `belarusian` alike.

I have not run the split-landscape, number-row, arrow-key, long-press-ordering or one-handed matrix here. Those were run against the Latin layout in #309, which shares the generator and the bottom row but not the row widths. I can run them against this one before you merge.

### Same three questions as #309

`Cyrillic/` is unambiguously the right directory here, and the name is in the language of all three subtypes it serves, so only the third applies: the file is generated, but the in-tree copy is canonical once merged, and I will hand-port generator changes rather than regenerate over your edits.

Generated from https://polish-typographic.com
